### PR TITLE
Use forked php-fpm role

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,4 +3,4 @@ dependencies:
   - role: ANXS.generic-directories
   - role: geerlingguy.mysql
   - role: jdauphant.nginx
-  - role: nbz4live.php-fpm
+  - role: Jberlinsky.php-fpm


### PR DESCRIPTION
In order to deal with Ansible 1.9.1, use a forked role that manually restarts services
